### PR TITLE
Avoid plot overwriting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=UserWarning)
 
-__version__ = "1.8.9"
+__version__ = "2.0.0"
 
 from .aggregator.aggregator import Aggregator
 from .subject.subject import Subject

--- a/rest/resting_state.py
+++ b/rest/resting_state.py
@@ -172,10 +172,10 @@ class RestingState(Build_RS):
 
             else:
                   if run == "ALL":
-                       output_name = f"sub-{self.sub_id}_aggregated-matrix.jpg"
+                       output_name = f"sub-{self.sub_id}_aggregated-matrix-glass-brain.jpg"
 
                   else:
-                       output_name = f"sub-{self.sub_id}_run-{run}_connectome.jpg"
+                       output_name = f"sub-{self.sub_id}_run-{run}_connectome-glass-brain.jpg"
 
             try:
                   # Gets coordinates from 4D probabilistic atlas
@@ -530,9 +530,11 @@ class RestingState(Build_RS):
 
 
 
-      def matrix_to_dataframe(self, incoming_matrix=None, labels=None, a_comp_cor=True,
+      def _matrix_to_dataframe(self, incoming_matrix=None, labels=None, a_comp_cor=True,
                               t_comp_cor=True):
             """
+            IN DEVELOPMENT
+            
             Renders a one-dimensional Pandas DataFrame with all functional connection correlations mapped.
             You can supply your own matrix and labels, or use the default MSDL atlas values
 


### PR DESCRIPTION
Simple PR to accomplish the following:

* Avoid naming convention overwriting when saving plots
* Move `matrix_to_dataframe` function to development